### PR TITLE
feat: add edit button

### DIFF
--- a/app/docs/[[...slug]]/page.tsx
+++ b/app/docs/[[...slug]]/page.tsx
@@ -19,8 +19,19 @@ export default async function Page({
 
   const MDX = page.data.body;
 
+  const path = `content/docs/${page.file.path}`;
+
   return (
-    <DocsPage toc={page.data.toc} full={page.data.full}>
+    <DocsPage
+      toc={page.data.toc}
+      full={page.data.full}
+      editOnGithub={{
+        repo: "devrel-directory",
+        owner: "fabianhug",
+        sha: "main",
+        path,
+      }}
+    >
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
       <DocsBody>


### PR DESCRIPTION
This pull request includes a change to the `app/docs/[[...slug]]/page.tsx` file to enhance the functionality of the `DocsPage` component. The most important change is the addition of the `editOnGithub` prop to the `DocsPage` component, which allows users to edit the documentation directly on GitHub.

Enhancements to `DocsPage` component:

* `app/docs/[[...slug]]/page.tsx`: Added the `editOnGithub` prop to the `DocsPage` component, enabling users to edit the documentation on GitHub. This includes specifying the repository, owner, branch (`sha`), and file path. ([app/docs/[[...slug]]/page.tsxR22-R34](diffhunk://#diff-67726b9e6c91989ba4ae3b6fecbca5fe8a07a33bb6842312a46843e33b98f9fbR22-R34))